### PR TITLE
fix(shortcode): allow passing html attributes to image

### DIFF
--- a/content/posts/2015-03-11-boxen-tips-and-tricks.md
+++ b/content/posts/2015-03-11-boxen-tips-and-tricks.md
@@ -9,7 +9,7 @@ laptop? We'll look at Boxen and how to set it up to get the most out of it.
 """
 proof = false
 +++
-{{< image "automate-all-the-things.jpg" "Automate all the things!" "float-right" >}}
+{{< image "automate-all-the-things.jpg" "Automate all the things!" `class="float-right"` >}}
 
 A while back I wrote about [The Perfect Dev Setup]({{< ref "2012-02-02-perfect-dev-setup-lion" >}}) that walked through what I considered to be (at the time), the perfect development setup. Part of the reason I wrote a post about it so that I could repeat it on any machine that I used, but it would still take time and copy/pasting commands. Surely there must be a better way?
 

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,6 +1,6 @@
 {{ with resources.Get (path.Join "images" (index .Params 0)) }}
   <img
-    {{ with index $.Params 2 }}class="{{ . }}"{{ end }}
+    {{ index $.Params 2 | safeHTMLAttr }}
     src="{{ .RelPermalink }}"
     width="{{ .Width }}"
     height="{{ .Height }}"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ export default {
     './content/**/*.{html,js,md}',
     './layouts/**/*.{html,js}',
   ],
-  safelist: [{ pattern: /^hero-/ }, 'float-right'],
+  safelist: [{ pattern: /^hero-/ }],
   theme: {
     heroes: [
       'main',


### PR DESCRIPTION
Any time we wanted to apply a class to an image, we'd have to add that class to Tailwind's safelist. By passing arbitrary html attributes, it will catch these and we don't need to add them to our list